### PR TITLE
Use collate_fn to skip corrupt images without using recursion

### DIFF
--- a/clip_retrieval/clip_inference.py
+++ b/clip_retrieval/clip_inference.py
@@ -89,7 +89,7 @@ def get_image_dataset():
                     image_tensor = self.image_transform(Image.open(image_file))
                 except (UnidentifiedImageError, OSError):
                     print(f"Failed to load image {image_file}. Skipping.")
-                    return None # return None to be filtered in the batch collate_fn
+                    return None  # return None to be filtered in the batch collate_fn
 
                 output["image_filename"] = str(image_file)
                 output["image_tensor"] = image_tensor
@@ -107,6 +107,7 @@ def get_image_dataset():
                 output["metadata"] = metadata
 
             return output
+
     return ImageDataset
 
 
@@ -282,6 +283,7 @@ class OutputSink:
         self.__write_batch()
         self.__init_batch()
 
+
 def clip_inference(
     input_dataset,
     output_folder,
@@ -305,7 +307,7 @@ def clip_inference(
     import clip  # pylint: disable=import-outside-toplevel
     from sentence_transformers import SentenceTransformer  # pylint: disable=import-outside-toplevel
     from torch.utils.data import DataLoader  # pylint: disable=import-outside-toplevel
-    from torch.utils.data.dataloader import default_collate # pylint: disable=import-outside-toplevel
+    from torch.utils.data.dataloader import default_collate  # pylint: disable=import-outside-toplevel
     import torch  # pylint: disable=import-outside-toplevel
 
     device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/clip_retrieval/clip_inference.py
+++ b/clip_retrieval/clip_inference.py
@@ -337,7 +337,6 @@ def clip_inference(
         raise Exception(f"No such input format {input_format}")
 
     def collate_fn(batch):
-        """collate_fn is a pytorch collate_fn that returns a dictionary of tensors"""
         batch = list(filter(lambda x: x is not None, batch))
         return default_collate(batch)
 

--- a/clip_retrieval/clip_inference.py
+++ b/clip_retrieval/clip_inference.py
@@ -2,7 +2,7 @@
 
 #!pip install clip-anytorch fire
 import fire
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 import json
 import fsspec
 from io import BytesIO
@@ -87,7 +87,7 @@ def get_image_dataset():
                 try:
                     image_file = self.image_files[key]
                     image_tensor = self.image_transform(Image.open(image_file))
-                except:
+                except (UnidentifiedImageError, OSError):
                     print(f"Failed to load image {image_file}. Skipping.")
                     return None # return None to be filtered in the batch collate_fn
 
@@ -281,7 +281,6 @@ class OutputSink:
             return
         self.__write_batch()
         self.__init_batch()
-
 
 def clip_inference(
     input_dataset,


### PR DESCRIPTION
I've tested this on a particularly annoying version of Wikiart with captions I have that has many corrupt images. Works well. 
![Screenshot from 2021-12-03 19-28-48](https://user-images.githubusercontent.com/3994972/144692210-2d7889a3-530a-4e4b-a3e8-11da5e284153.png)
