### PR TITLE
Log error for unsupported input_format

### DIFF
--- a/clip_retrieval/clip_inference/main.py
+++ b/clip_retrieval/clip_inference/main.py
@@ -55,6 +55,9 @@ def main(
             sample_count = len(keys)
         elif input_format == "webdataset":
             sample_count = len(input_dataset) * wds_number_file_per_input_file
+        else:
+            print("Unsupported input_format")
+            return
 
         if sample_count == 0:
             print("no sample found")


### PR DESCRIPTION
Currently if input_format is neither `"files"` nor `"webdataset"`  the user gets an error that `sample_count` is referenced prior to assignment, which is rather cryptic. This change addresses that failure mode.