### PR TITLE
add clip-client python module for remotely searching backend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ This scripts works for small datasets. For larger ones, please check [notebook/s
 Clip back is a simple knn service backend. If using both hdf5 and faiss memory mapping, it uses only the memory used by clip which is 4GB.
 
 Run (output_folder is the output of clip index)
+
 ```bash
 echo '{"example_index": "output_folder"}' > indices_paths.json
 clip-retrieval back --port 1234 --indices-paths indices_paths.json
@@ -294,6 +295,55 @@ clip-retrieval-front 3005
 ```
 
 You can also run it with `clip-retrieval front` or back from the python package.
+
+## Clip client
+
+Clip client is a simple python module that allows you to query the backend remotely.
+
+```python
+from clip_retrieval.clip_client import ClipClient, Modality
+
+client = ClipClient(
+    url="https://knn5.laion.ai/knn-service",
+    aesthetic_score=9,
+    aesthetic_weight=0.5,
+    modality=Modality.IMAGE,
+    num_images=40,
+    num_result_ids=3000,
+)
+```
+
+### Query by text
+
+```python
+results = client.query(text="an image of a cat")
+```
+
+### Query by image
+
+Images can be searched via local path or url.
+
+```python
+cat_results = client.query(image="cat.jpg")
+dog_results = client.query(image="https://example.com/dog.jpg")
+```
+
+### Query a directory of images
+
+```python
+all_results = [result for result in [client.query(image=image) for image in os.listdir("my-images")]]
+with open("search-results.json", "w") as f:
+    json.dump(all_results, f)
+```
+
+### Create a dataset
+
+You can create a dataset using the saved json results and the tool `img2dataset`.
+
+```sh
+pip install img2dataset
+img2datset "search-results.json" --input_format="json" --output_folder="laion-enhanced-images"
+```
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ This scripts works for small datasets. For larger ones, please check [notebook/s
 Clip back is a simple knn service backend. If using both hdf5 and faiss memory mapping, it uses only the memory used by clip which is 4GB.
 
 Run (output_folder is the output of clip index)
-
 ```bash
 echo '{"example_index": "output_folder"}' > indices_paths.json
 clip-retrieval back --port 1234 --indices-paths indices_paths.json
@@ -317,6 +316,8 @@ client = ClipClient(
 
 ```python
 results = client.query(text="an image of a cat")
+results[0]
+> {'url': 'https://finalmonsoon.files.wordpress.com/2017/10/kitten.jpg?w=404&', 'caption': 'kitten', 'id': 5098117701, 'similarity': 0.9367108941078186}
 ```
 
 ### Query by image

--- a/clip_retrieval/clip_client.py
+++ b/clip_retrieval/clip_client.py
@@ -1,0 +1,127 @@
+"""Clip client is a simple python module that allows you to query the backend remotely."""
+
+import base64
+import enum
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import requests
+
+
+class Modality(enum.Enum):
+    IMAGE = "image"
+    TEXT = "text"
+
+
+class ClipClient:
+    """Remotely query the CLIP backend via REST"""
+
+    def __init__(
+        self,
+        url: str,
+        result_dir: str = "results",
+        indice_name: str = "laion5B",
+        use_mclip: bool = False,
+        aesthetic_score: int = 9,
+        aesthetic_weight: float = 0.5,
+        modality: Modality = Modality.IMAGE,
+        num_images: int = 40,
+        num_result_ids: int = 3000,
+    ):
+        """
+        modality: which "modality" to search over, text or image, defaults to image.
+        num_images: number of images to return (may be less).
+        indice_name: which indice to search over, laion5B or laion_400m.
+        num_result_ids: number of result ids to be returned.
+        use_mclip: whether to use mclip, a multilingual version of clip.
+        aesthetic_score: ranking score for aesthetic, higher is prettier.
+        aesthetic_weight: weight of the aesthetic score, between 0 and 1.
+        """
+        self.url = url
+        self.result_dir = Path(result_dir)
+        assert not self.result_dir.exists(), f"{self.result_dir} already exists. Move or delete it and try again."
+        self.result_dir.mkdir(parents=True)
+        self.indice_name = indice_name
+        self.use_mclip = use_mclip
+        self.aesthetic_score = aesthetic_score
+        self.aesthetic_weight = aesthetic_weight
+        self.modality = modality.value
+        self.num_images = num_images
+        self.num_result_ids = num_result_ids
+
+    def query(
+        self,
+        text: str = None,
+        image: str = None,
+    ) -> List[Dict]:
+        """
+        Given text or image/s, search for other captions/images that are semantically similar.
+
+        Args:
+            text: text to be searched semantically.
+            image: base64 string of image to be searched semantically
+
+        Returns:
+            List of dictionaries containing the results.
+        """
+        if text and image:
+            raise ValueError("Only one of text or image can be provided.")
+        if text:
+            print(f"Searching for {text}")
+            return self.__search_knn_api__(text=text)
+        elif image:
+            if image.startswith("http"):
+                print(f"Searching via image at url {image}")
+                return self.__search_knn_api__(image_url=image)
+            else:
+                print(f"Searching for image at path {image}")
+                assert Path(image).exists(), f"{image} does not exist."
+                return self.__search_knn_api__(image=image)
+        else:
+            raise ValueError("Either text or image must be provided.")
+
+    def __search_knn_api__(
+        self,
+        text: str = None,
+        image: str = None,
+        image_url: str = None,
+    ) -> List:
+        """
+        This function is used to send the request to the knn service.
+        It represents a direct API call and should not be called directly outside the package.
+
+        Args:
+            text: text to be searched semantically.
+            image: base64 string of image to be searched semantically.
+
+        Returns:
+            List of dictionaries containing the results.
+        """
+        if image:
+            # Convert image to base64 string
+            with open(image, "rb") as image_file:
+                encoded_string = base64.b64encode(image_file.read())
+                image = str(encoded_string.decode("utf-8"))
+        return requests.post(
+            self.url,
+            data=json.dumps(
+                {
+                    "text": text,
+                    "image": image,
+                    "image_url": image_url,
+                    "deduplicate": True,
+                    "use_safety_model": True,
+                    "use_violence_detector": True,
+                    "indice_name": self.indice_name,
+                    "use_mclip": self.use_mclip,
+                    "aesthetic_score": self.aesthetic_score,
+                    "aesthetic_weight": self.aesthetic_weight,
+                    "modality": self.modality,
+                    "num_images": self.num_images,
+                    "num_result_ids": self.num_result_ids,
+                }
+            ),
+        ).json()[
+            0 : self.num_images
+        ]  # The "last half" is used for formatting on the website.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,4 +6,6 @@ pytest-cov==3.0.0
 pytest-xdist==2.5.0
 pytest==7.0.1
 types-setuptools
+types-requests
+types-certifi
 pyspark

--- a/tests/test_clip_client.py
+++ b/tests/test_clip_client.py
@@ -1,0 +1,46 @@
+"""Test the ClipClient class."""
+from pathlib import Path
+import tempfile
+from clip_retrieval.clip_client import ClipClient, Modality
+
+test_url = "https://placekitten.com/400/600"
+test_caption = "an image of a cat"
+test_image_1 = "tests/test_clip_inference/test_images/123_456.jpg"
+test_image_2 = "tests/test_clip_inference/test_images/416_264.jpg"
+
+knn_service_url = "https://knn5.laion.ai/knn-service"
+
+
+def test_query():
+    """
+    Test the ClipClient.query() method.
+    """
+    # Create a temporary directory to store the results
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Create a client
+        client = ClipClient(
+            url=knn_service_url,
+            result_dir=Path(tmp_dir).joinpath("results"),
+            indice_name="laion5B",
+            use_mclip=False,
+            aesthetic_score=9,
+            aesthetic_weight=0.5,
+            modality=Modality.IMAGE,
+            num_images=40,
+            num_result_ids=3000,
+        )
+
+        # test search via text
+        text_search_results = client.query(text=test_caption)
+        # Note, this test is highly non-deterministic
+        assert len(text_search_results) > 0, "No results found"
+
+        # test search via image
+        image_search_results = client.query(image=test_image_1)
+        # Note, this test is highly non-deterministic
+        assert len(image_search_results) > 0, "No results found"
+
+        # test search via url of image
+        image_url_search_results = client.query(image=test_url)
+        # Note, this test is highly non-deterministic
+        assert len(image_url_search_results) > 0, "No results found"


### PR DESCRIPTION
Well I couldn't quite merit the use of a context manager doing things synchronously - there's just not any state to keep track of. I noticed you use aiohttp here already, so if you'd like I can refactor to use that instead of requests?

Let me know if you have ideas how it could be better.