### PR TITLE
Improve logger reliability.

### DIFF
--- a/clip_retrieval/clip_inference/main.py
+++ b/clip_retrieval/clip_inference/main.py
@@ -68,7 +68,7 @@ def main(
         output_partition_count = int(sample_count / write_batch_size) + 1
 
     def reader_builder(sampler):
-        _, preprocess = load_clip(clip_model=clip_model, use_jit=use_jit)
+        _, preprocess = load_clip(clip_model, use_jit, batch_size)
         if input_format == "files":
             return FilesReader(
                 sampler,
@@ -106,6 +106,7 @@ def main(
             clip_model=clip_model,
             use_jit=use_jit,
             mclip_model=mclip_model,
+            warmup_batch_size=batch_size,
         )
 
     def writer_builder(i):

--- a/clip_retrieval/clip_inference/mapper.py
+++ b/clip_retrieval/clip_inference/mapper.py
@@ -16,13 +16,23 @@ def normalized(a, axis=-1, order=2):
 class ClipMapper:
     """transforms images and texts into clip embeddings"""
 
-    def __init__(self, enable_image, enable_text, enable_metadata, use_mclip, clip_model, use_jit, mclip_model):
+    def __init__(
+        self,
+        enable_image,
+        enable_text,
+        enable_metadata,
+        use_mclip,
+        clip_model,
+        use_jit,
+        mclip_model,
+        warmup_batch_size=1,
+    ):
         self.enable_image = enable_image
         self.enable_text = enable_text
         self.enable_metadata = enable_metadata
         self.use_mclip = use_mclip
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        model, _ = load_clip(clip_model, use_jit)
+        model, _ = load_clip(clip_model, use_jit, warmup_batch_size)
         self.model_img = model.encode_image
         self.model_txt = model.encode_text
         if use_mclip:

--- a/clip_retrieval/clip_inference/runner.py
+++ b/clip_retrieval/clip_inference/runner.py
@@ -31,6 +31,7 @@ class Runner:
         logger.start()
         iterator = reader.__iter__()
         while True:
+            begin_time = time.time()
             start_time = time.perf_counter()
             try:
                 batch = iterator.__next__()
@@ -43,13 +44,15 @@ class Runner:
             start_time = time.perf_counter()
             writer(embeddings)
             write_duration = time.perf_counter() - start_time
-            total_duration = read_duration + inference_duration + write_duration
+            end_time = time.time()
             logger(
                 {
+                    "start_time": begin_time,
+                    "end_time": end_time,
                     "read_duration": read_duration,
                     "inference_duration": inference_duration,
                     "write_duration": write_duration,
-                    "total_duration": total_duration,
+                    "total_duration": end_time - begin_time,
                     "sample_count": batch["image_tensor"].shape[0]
                     if "image_tensor" in batch
                     else batch["text_tokens"].shape[0],

--- a/tests/test_clip_client.py
+++ b/tests/test_clip_client.py
@@ -1,5 +1,6 @@
 """Test the ClipClient class."""
 import logging
+
 LOGGER = logging.getLogger(__name__)
 LOGGER.info("Test ClipClient.query()")
 from clip_retrieval.clip_client import ClipClient, Modality

--- a/tests/test_clip_inference/test_distributor.py
+++ b/tests/test_clip_inference/test_distributor.py
@@ -17,14 +17,14 @@ def test_distributor(distributor_kind):
 
     output_partition_count = 2
     num_prepro_workers = 8
-    batch_size = 2
+    batch_size = 8
     current_folder = os.path.dirname(__file__)
     folder = current_folder + "/test_images"
 
     with tempfile.TemporaryDirectory() as tmpdir:
 
         def reader_builder(sampler):
-            _, preprocess = load_clip()
+            _, preprocess = load_clip(warmup_batch_size=batch_size)
             return FilesReader(
                 sampler,
                 preprocess,
@@ -45,6 +45,7 @@ def test_distributor(distributor_kind):
                 clip_model="ViT-B/32",
                 use_jit=True,
                 mclip_model="",
+                warmup_batch_size=batch_size,
             )
 
         def logger_builder(i):

--- a/tests/test_clip_inference/test_main.py
+++ b/tests/test_clip_inference/test_main.py
@@ -25,7 +25,7 @@ def test_main():
             output_folder=tmpdir,
             input_format="files",
             cache_path=None,
-            batch_size=256,
+            batch_size=8,
             num_prepro_workers=8,
             enable_text=False,
             enable_image=True,

--- a/tests/test_clip_inference/test_reader.py
+++ b/tests/test_clip_inference/test_reader.py
@@ -17,7 +17,7 @@ def test_reader(file_format):
         input_dataset = [tar_folder + "/image1.tar", tar_folder + "/image2.tar"]
     batch_size = 2
     num_prepro_workers = 2
-    _, preprocess = load_clip()
+    _, preprocess = load_clip(warmup_batch_size=batch_size)
 
     output_partition_count = 2
     actual_values = []

--- a/tests/test_clip_inference/test_runner.py
+++ b/tests/test_clip_inference/test_runner.py
@@ -14,14 +14,14 @@ def test_runner():
 
     output_partition_count = 2
     num_prepro_workers = 8
-    batch_size = 2
+    batch_size = 8
     current_folder = os.path.dirname(__file__)
     folder = current_folder + "/test_images"
 
     with tempfile.TemporaryDirectory() as tmpdir:
 
         def reader_builder(sampler):
-            _, preprocess = load_clip()
+            _, preprocess = load_clip(warmup_batch_size=batch_size)
             return FilesReader(
                 sampler,
                 preprocess,
@@ -42,6 +42,7 @@ def test_runner():
                 clip_model="ViT-B/32",
                 use_jit=True,
                 mclip_model="",
+                warmup_batch_size=batch_size,
             )
 
         def logger_builder(i):

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -64,7 +64,7 @@ def test_end2end():
         input_format="webdataset",
         enable_metadata=True,
         write_batch_size=100000,
-        batch_size=512,
+        batch_size=8,
         cache_path=None,
     )
 


### PR DESCRIPTION
* try/catch to avoid swallowing errors
* do warmup in load clip so inference time is counted when hot
* fix missing lru cache in openclip
* save start/end time and use that to start counting sample/s only after initial load

Result: sample/s is ready to be read after about 1min instead of 4