### PR TITLE
Support OpenCLIP models in `clip_back`

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ clip-retrieval back --port 1234 --indices-paths indices_paths.json
 
 Options:
 * `--use_jit True` uses jit for the clip model
-* `--clip_model "ViT-B/32"` allows choosing the clip model to use
+* `--clip_model "ViT-B/32"` allows choosing the clip model to use. Prefix with `"open_clip:"` to use an [open_clip](https://github.com/mlfoundations/open_clip) model. 
 * `--enable_mclip_option True` loads the mclip model, making it possible to search in any language.
 * `--columns_to_return='["url", "image_path", "caption", "NSFW"]` allows you to specify which columns should be fetched from the metadata and returned by the backend. It's useful to specify less in case of hdf5 caching to speed up the queries.
 * `--enable_faiss_memory_mapping=True` option can be passed to use an index with memory mapping.

--- a/clip_retrieval/clip_back.py
+++ b/clip_retrieval/clip_back.py
@@ -854,7 +854,7 @@ def load_mclip(clip_model):
 def load_clip_index(clip_options):
     """load the clip index"""
     import torch  # pylint: disable=import-outside-toplevel
-    from .clip_inference.load_clip import load_clip  # pylint: disable=import-outside-toplevel
+    from clip_retrieval.load_clip import load_clip  # pylint: disable=import-outside-toplevel
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model, preprocess = load_clip(clip_options.clip_model, use_jit=clip_options.use_jit, device=device)

--- a/clip_retrieval/clip_back.py
+++ b/clip_retrieval/clip_back.py
@@ -671,6 +671,8 @@ def get_aesthetic_embedding(model_type):
         model_type = "vit_b_32"
     elif model_type == "ViT-L/14":
         model_type = "vit_l_14"
+    else:
+        raise ValueError(f"Aesthetic embedding for {model_type} not available.")
 
     fs, _ = fsspec.core.url_to_fs(
         f"https://github.com/LAION-AI/aesthetic-predictor/blob/main/{model_type}_embeddings/rating0.npy?raw=true"
@@ -703,7 +705,7 @@ def load_violence_detector(clip_model):
     elif clip_model == "ViT-B/32":
         name = "violence_detection_vit_b_32.npy"
     else:
-        raise ValueError("Unknown clip model")
+        raise ValueError(f"Violence detector for {clip_model} not available.")
 
     url_model = root_url + "/" + name
     prompt_file = cache_folder + "/" + name
@@ -730,7 +732,7 @@ def load_safety_model(clip_model):
         model_dir = cache_folder + "/clip_autokeras_nsfw_b32"
         dim = 512
     else:
-        raise ValueError("Unknown clip model")
+        raise ValueError(f"Safety model for {clip_model} not available.")
     if not os.path.exists(model_dir):
         os.makedirs(cache_folder, exist_ok=True)
 
@@ -824,14 +826,6 @@ def dict_to_clip_options(d, clip_options):
 
 
 @lru_cache(maxsize=None)
-def load_clip(clip_model="ViT-B/32", use_jit=True, device="cpu"):
-    import clip  # pylint: disable=import-outside-toplevel
-
-    model, preprocess = clip.load(clip_model, device=device, jit=use_jit)
-    return model, preprocess
-
-
-@lru_cache(maxsize=None)
 def load_mclip(clip_model):
     """load the mclip model"""
     from multilingual_clip import pt_multilingual_clip  # pylint: disable=import-outside-toplevel
@@ -842,6 +836,8 @@ def load_mclip(clip_model):
         model_name = "M-CLIP/XLM-Roberta-Large-Vit-L-14"
     elif clip_model == "ViT-B/32":
         model_name = "M-CLIP/XLM-Roberta-Large-Vit-B-32"
+    else:
+        raise ValueError(f"Multi-lingual version of {clip_model} not available.")
 
     model = pt_multilingual_clip.MultilingualCLIP.from_pretrained(model_name)
     model.eval()
@@ -858,6 +854,7 @@ def load_mclip(clip_model):
 def load_clip_index(clip_options):
     """load the clip index"""
     import torch  # pylint: disable=import-outside-toplevel
+    from .clip_inference.load_clip import load_clip  # pylint: disable=import-outside-toplevel
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model, preprocess = load_clip(clip_options.clip_model, use_jit=clip_options.use_jit, device=device)

--- a/clip_retrieval/clip_back.py
+++ b/clip_retrieval/clip_back.py
@@ -225,7 +225,7 @@ class KnnService(Resource):
                     with torch.no_grad():
                         text_features = clip_resource.model.encode_text(text)
                     text_features /= text_features.norm(dim=-1, keepdim=True)
-                    query = text_features.cpu().detach().numpy().astype("float32")
+                    query = text_features.cpu().to(torch.float32).detach().numpy()
         elif image_input is not None or image_url_input is not None:
             if image_input is not None:
                 binary_data = base64.b64decode(image_input)
@@ -239,7 +239,7 @@ class KnnService(Resource):
                 with torch.no_grad():
                     image_features = clip_resource.model.encode_image(prepro)
                 image_features /= image_features.norm(dim=-1, keepdim=True)
-                query = image_features.cpu().detach().numpy().astype("float32")
+                query = image_features.cpu().to(torch.float32).detach().numpy()
         elif embedding_input is not None:
             query = np.expand_dims(np.array(embedding_input).astype("float32"), 0)
 

--- a/clip_retrieval/clip_inference/load_clip.py
+++ b/clip_retrieval/clip_inference/load_clip.py
@@ -65,9 +65,10 @@ def load_clip_without_warmup(clip_model, use_jit, device, clip_cache_path):
 
 
 @lru_cache(maxsize=None)
-def load_clip(clip_model="ViT-B/32", use_jit=True, warmup_batch_size=1, clip_cache_path=None):
+def load_clip(clip_model="ViT-B/32", use_jit=True, warmup_batch_size=1, device=None, clip_cache_path=None):
     """Load clip then warmup"""
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
     model, preprocess = load_clip_without_warmup(clip_model, use_jit, device, clip_cache_path)
 
     print(f"warming up with batch size {warmup_batch_size} on {device}")

--- a/clip_retrieval/clip_inference/mapper.py
+++ b/clip_retrieval/clip_inference/mapper.py
@@ -1,7 +1,7 @@
 """mapper module transform images and text to embeddings"""
 
 import torch
-from .load_clip import load_clip
+from clip_retrieval.load_clip import load_clip
 from sentence_transformers import SentenceTransformer
 
 

--- a/clip_retrieval/clip_inference/worker.py
+++ b/clip_retrieval/clip_inference/worker.py
@@ -14,9 +14,9 @@ from braceexpand import braceexpand
 from clip_retrieval.clip_inference.runner import Runner
 from clip_retrieval.clip_inference.mapper import ClipMapper
 from clip_retrieval.clip_inference.writer import NumpyWriter
-from clip_retrieval.clip_inference.load_clip import load_clip
 from clip_retrieval.clip_inference.logger import LoggerWriter
 from clip_retrieval.clip_inference.reader import FilesReader, WebdatasetReader
+from clip_retrieval.load_clip import load_clip
 
 
 def worker(

--- a/clip_retrieval/load_clip.py
+++ b/clip_retrieval/load_clip.py
@@ -65,7 +65,7 @@ def load_clip_without_warmup(clip_model, use_jit, device, clip_cache_path):
 
 
 @lru_cache(maxsize=None)
-def load_clip(clip_model="ViT-B/32", use_jit=True, warmup_batch_size=1, device=None, clip_cache_path=None):
+def load_clip(clip_model="ViT-B/32", use_jit=True, warmup_batch_size=1, clip_cache_path=None, device=None):
     """Load clip then warmup"""
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/tests/test_clip_inference/test_reader.py
+++ b/tests/test_clip_inference/test_reader.py
@@ -3,7 +3,7 @@ from clip_retrieval.clip_inference.reader import FilesReader, WebdatasetReader
 from clip_retrieval.clip_inference.runner import Sampler
 import os
 
-from clip_retrieval.clip_inference.load_clip import load_clip
+from clip_retrieval.load_clip import load_clip
 
 
 @pytest.mark.parametrize("file_format", ["files", "webdataset"])

--- a/tests/test_clip_inference/test_runner.py
+++ b/tests/test_clip_inference/test_runner.py
@@ -3,7 +3,7 @@ from clip_retrieval.clip_inference.runner import Runner
 from clip_retrieval.clip_inference.reader import FilesReader
 from clip_retrieval.clip_inference.mapper import ClipMapper
 from clip_retrieval.clip_inference.writer import NumpyWriter
-from clip_retrieval.clip_inference.load_clip import load_clip
+from clip_retrieval.load_clip import load_clip
 import os
 import numpy as np
 import tempfile


### PR DESCRIPTION
This pull requests extends `clip_back` to support OpenCLIP models, including the latest from OpenCLIP 2.x releases (ViT-H/14, ...). For example, when running 

```shell
clip-retrieval back --port 1234 --indices-paths indices_paths.json
```

with the following `indices_paths.json` file

```json
{
    "my-index": {
        "indice_folder": "my-index-folder",
        "clip_model": "open_clip:ViT-H-14",
        "use_jit": false,
        "columns_to_return": ["image_path", "caption"],
        "enable_mclip_option": false,
        "enable_faiss_memory_mapping": false,
        "enable_hdf5": true,
        "use_arrow": false,
        "reorder_metadata_by_ivf_index": false,
        "provide_safety_model": false,
        "provide_violence_detector": false,
        "provide_aesthetic_embeddings": false
    }
}
```

then queries are encoded with the recently released OpenCLIP `ViT-H-14` model. Current limitation is that using OpenCLIP models require `provide_safety_model`, `provide_violence_detector` and `provide_aesthetic_embeddings` to be set to `false`.
