### PR TITLE
Update README query by embedding section to match API

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ dog_results = client.query(image="https://example.com/dog.jpg")
 You can also find captioned images similar to a clip embedding you provide.
 
 ```python
-cat_results = client.query(embedding=cat_embedding)
+cat_results = client.query(embedding_input=cat_embedding)
 ```
 
 ### Query a directory of images


### PR DESCRIPTION
The keyword argument to `client.query` when  using an embedding is `embedding_input` and not `embedding`. Updated README accordingly.