### PR TITLE
Enable filtering by image with clip-retrieval filter

### DIFF
--- a/clip_retrieval/clip_filter.py
+++ b/clip_retrieval/clip_filter.py
@@ -14,9 +14,10 @@ def clip_filter(query, output_folder, indice_folder, num_results=100, threshold=
     from pathlib import Path  # pylint: disable=import-outside-toplevel
     import pandas as pd  # pylint: disable=import-outside-toplevel
     import clip  # pylint: disable=import-outside-toplevel
+    from PIL import Image  # pylint: disable=import-outside-toplevel
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    model, _ = clip.load("ViT-B/32", device=device, jit=False)
+    model, preprocess = clip.load("ViT-B/32", device=device, jit=False)
 
     data_dir = Path(indice_folder + "/metadata")
     df = pd.concat(pd.read_parquet(parquet_file) for parquet_file in sorted(data_dir.glob("*.parquet")))
@@ -32,25 +33,27 @@ def clip_filter(query, output_folder, indice_folder, num_results=100, threshold=
         "image_index": image_index,
     }
 
-    text_input = query
     image_index = indices_loaded["image_index"]
     image_list = indices_loaded["image_list"]
     if not os.path.exists(output_folder):
         os.mkdir(output_folder)
-
-    text = clip.tokenize([text_input]).to(device)
-    text_features = model.encode_text(text)
-    text_features /= text_features.norm(dim=-1, keepdim=True)
-    query = text_features.cpu().detach().numpy().astype("float32")
+    if query.endswith((".png", ".jpg", ".jpeg", ".bmp")) and os.path.isfile(query):
+        im = Image.open(query)
+        query_features = model.encode_image(preprocess(im).unsqueeze(0).to(device))
+    else:
+        text = clip.tokenize([query]).to(device)
+        query_features = model.encode_text(text)
+    query_features /= query_features.norm(dim=-1, keepdim=True)
+    query_features = query_features.cpu().detach().numpy().astype("float32")
 
     index = image_index
 
     if threshold is not None:
-        _, d, i = index.range_search(query, threshold)
-        print(f"Found {i.shape} items with query '{text_input}' and threshold {threshold}")
+        _, d, i = index.range_search(query_features, threshold)
+        print(f"Found {i.shape} items with query '{query}' and threshold {threshold}")
     else:
-        d, i = index.search(query, num_results)
-        print(f"Found {num_results} items with query '{text_input}'")
+        d, i = index.search(query_features, num_results)
+        print(f"Found {num_results} items with query '{query}'")
         i = i[0]
         d = d[0]
 


### PR DESCRIPTION
Just added a check to see if the query is an image path and using `encode_image` to generate or embedding to filter by instead of `encode_text`. Might be worth having a separate flag for querying by image, but this felt the most intuitive to me.