### PR TITLE
Default context to fix bug with some requests returning 404

### DIFF
--- a/clip_retrieval/clip_back.py
+++ b/clip_retrieval/clip_back.py
@@ -155,6 +155,7 @@ class IndicesList(Resource):
 
 @DOWNLOAD_TIME.time()
 def download_image(url):
+    """Download an image from a url and return a byte stream"""
     urllib_request = urllib.request.Request(
         url,
         data=None,

--- a/clip_retrieval/clip_back.py
+++ b/clip_retrieval/clip_back.py
@@ -12,6 +12,7 @@ import json
 from io import BytesIO
 from PIL import Image
 import base64
+import ssl
 import os
 import fire
 from pathlib import Path
@@ -159,7 +160,10 @@ def download_image(url):
         data=None,
         headers={"User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0"},
     )
-    with urllib.request.urlopen(urllib_request, timeout=10) as r:
+    urllib_context = ssl.create_default_context()
+    urllib_context.set_alpn_protocols(["http/1.1"])
+
+    with urllib.request.urlopen(urllib_request, timeout=10, context=urllib_context) as r:
         img_stream = io.BytesIO(r.read())
     return img_stream
 


### PR DESCRIPTION
This change is to fix an issue with HTTP requests returning 404 for some URLs, despite the URL functioning as expected in browsers, curl, wget, etc. Only affects Python versions earlier than **3.10**.

**Bug Description:**
When using a Python version earlier than **3.10**, some HTTP requests return 404 through the `urllib.request.urlopen` function. This seems to be happening most often with Wordpress CDN urls. Some examples:
```
https://i0.wp.com/live.staticflickr.com/65535/51671200033_559f07d991_b.jpg?resize=450%2C300
https://i0.wp.com/live.staticflickr.com/65535/51882032946_514849a9c0_b.jpg?resize=450%2C300
https://i0.wp.com/live.staticflickr.com/65535/52563715365_4c0d7bd19b_b.jpg?resize=450%2C300
```
These urls work as expected in the browser, but fail with the aforementioned function.

**Fix:**
Adding a default context and setting the ALPN protocol seems to resolve the issue. The change should be pretty safe as it's the same change in Python 3.10+. 

Discussion: https://bugs.python.org/issue40968
Source: https://github.com/python/cpython/commit/f97406be4c0a02c1501c7ab8bc8ef3850eddb962