### PR TITLE
Update outdated URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ First pick a dataset of image urls and captions ([examples](https://github.com/r
 You may want to run `export CUDA_VISIBLE_DEVICES=` to avoid using your GPU if it doesn't have enough VRAM.
 
 ```
-wget https://github.com/rom1504/img2dataset/raw/main/tests/test_1000.parquet
+wget https://github.com/rom1504/img2dataset/raw/main/tests/test_files/test_1000.parquet
 clip-retrieval end2end test_1000.parquet /tmp/my_output
 ```
 


### PR DESCRIPTION
The old URL fails:
```
(base) kaur@macbook ~ % wget https://github.com/rom1504/img2dataset/raw/main/tests/test_1000.parquet
--2023-02-17 10:20:21--  https://github.com/rom1504/img2dataset/raw/main/tests/test_1000.parquet
Resolving github.com (github.com)... 140.82.121.4
Connecting to github.com (github.com)|140.82.121.4|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-02-17 10:20:21 ERROR 404: Not Found.
```

The new URL works:
```
(base) kaur@macbook ~ % wget https://github.com/rom1504/img2dataset/raw/main/tests/test_files/test_1000.parquet
--2023-02-17 10:20:31--  https://github.com/rom1504/img2dataset/raw/main/tests/test_files/test_1000.parquet
Resolving github.com (github.com)... 140.82.121.4
Connecting to github.com (github.com)|140.82.121.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://raw.githubusercontent.com/rom1504/img2dataset/main/tests/test_files/test_1000.parquet [following]
--2023-02-17 10:20:31--  https://raw.githubusercontent.com/rom1504/img2dataset/main/tests/test_files/test_1000.parquet
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.110.133, 185.199.109.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 131936 (129K) [application/octet-stream]
Saving to: ‘test_1000.parquet’

test_1000.parquet   100%[===================>] 128,84K  --.-KB/s    in 0,03s   

2023-02-17 10:20:31 (4,83 MB/s) - ‘test_1000.parquet’ saved [131936/131936]
```