### PR TITLE
Add single text file for text embeddings

### DIFF
--- a/clip_retrieval/clip_inference/reader.py
+++ b/clip_retrieval/clip_inference/reader.py
@@ -14,8 +14,12 @@ def folder_to_keys(folder, enable_text=True, enable_image=True, enable_metadata=
     metadata_files = None
     image_files = None
     if enable_text:
-        text_files = [*path.glob("**/*.txt")]
-        text_files = {text_file.stem: text_file for text_file in text_files}
+        if path.is_file():
+            text_files = {text: text for text in path.read_text().split("\n") if text}
+            print(f"dataset is {len(text_files)}", flush=True)
+        else:
+            text_files = [*path.glob("**/*.txt")]
+            text_files = {text_file.stem: text_file for text_file in text_files}
     if enable_image:
         image_files = [
             *path.glob("**/*.png"),
@@ -94,7 +98,10 @@ def get_image_dataset():
 
             if self.enable_text:
                 text_file = self.text_files[key]
-                caption = text_file.read_text()
+                if isinstance(text_file, Path):
+                    caption = text_file.read_text()
+                else:
+                    caption = text_file
                 tokenized_text = self.tokenizer(caption)
                 output["text_tokens"] = tokenized_text
                 output["text"] = caption

--- a/clip_retrieval/clip_inference/worker.py
+++ b/clip_retrieval/clip_inference/worker.py
@@ -46,7 +46,8 @@ def worker(
     if input_format == "webdataset" and not isinstance(input_dataset, list):
         input_dataset = list(braceexpand(input_dataset))
 
-    print(f"dataset is {len(input_dataset)}", flush=True)
+    if not isinstance(input_dataset, str):
+        print(f"dataset is {len(input_dataset)}", flush=True)
 
     def reader_builder(sampler):
         _, preprocess = load_clip(


### PR DESCRIPTION
Hi there!

Previously, the code required individual text files for each text embedding, which could be quite cumbersome to manage. In my update, I've changed the code to use just one file with all texts inside, which will make it much faster since the program only needs to open one file instead of multiple files.

I believe this change will make the code more efficient, and I hope you find it helpful. Thank you for considering my contribution!

Best regards,
Lucas