### PR TITLE
Fixed the link to the aesthetic detector in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ During initialization you can specify a few parameters:
 
 * `backend_url`: the url of the backend. (required)
 * `indice_name`: specify the name of the index you want to use. (required)
-* `aesthetic_score`: the aesthetic score as rated by [aesthetic_detector](https://github.com/rom1504/aesthetic_detector). Default is `9`.
+* `aesthetic_score`: the aesthetic score as rated by [aesthetic-predictor](https://github.com/LAION-AI/aesthetic-predictor). Default is `9`.
 * `use_mclip`: whether to use a multi-lingual version of CLIP. Default is `False`.
 * `aesthetic_weight`: the weight of the aesthetic score. Default is `0.5`
 * `modality`: search over image or text in the index, one of `Multimodal.IMAGE` or `Multimodal.TEXT`. Default is `Multimodal.IMAGE`.


### PR DESCRIPTION
The URL of aesthetic detector seems to have changed to https://github.com/LAION-AI/aesthetic-predictor.

this fixes #269 
