### PR TITLE
Updating instructions for H14 creation

### DIFF
--- a/docs/laion5B_h14_back.md
+++ b/docs/laion5B_h14_back.md
@@ -8,7 +8,7 @@
    - `cd /somehwere/with/lots/of/space`
 4. Download the index parts from the hugging-face repository
    - `mkdir index-parts && cd index-parts`
-   - `for i in {00..79}; do aria2c -x 16 https://huggingface.co/datasets/laion/laion5b-h14-index/resolve/main/index-parts/$i.index; done`
+   - `for i in {00..79}; do aria2c -x 16 https://huggingface.co/datasets/laion/laion5b-h14-index/resolve/main/index-parts/$i.index -o $i.parquet; done`
    - `cd ..`
 5. Combine the index parts using the following command
    - `clip-retrieval index_combiner --input_folder "index-parts" --output_folder "combined-indices"`
@@ -16,20 +16,16 @@
 
    - ***multi embeddings***
         - `mkdir multi-embeddings && cd multi-embeddings`
-        - `for i in {0000..2268}; do aria2c -x 16 https://huggingface.co/datasets/laion/laion2b-multi-vit-h-14-embeddings/resolve/main/metadata/metadata_$i.parquet; done`
+        - `for i in {0000..2268}; do aria2c -x 16 https://huggingface.co/datasets/laion/laion2b-multi-vit-h-14-embeddings/resolve/main/metadata/metadata_$i.parquet -o $i.parquet; done`
         - `cd ..`
    - ***english embeddings***
         - `mkdir en-embeddings && cd en-embeddings`
-        - `for i in {0000..2313}; do aria2c -x 16 https://huggingface.co/datasets/laion/laion2b-en-vit-h-14-embeddings/resolve/main/metadata/metadata_$i.parquet; done`
+        - `for i in {0000..2313}; do aria2c -x 16 https://huggingface.co/datasets/laion/laion2b-en-vit-h-14-embeddings/resolve/main/metadata/metadata_$i.parquet -o $i.parquet; done`
         - `cd ..`
    - ***nolang embeddings***
         - `mkdir nolang-embeddings && nolang en-embeddings`
-        - `for i in {0000..1273}; do aria2c -x 16 https://huggingface.co/datasets/laion/laion1b-nolang-vit-h-14-embeddings/resolve/main/metadata/metadata_$i.parquet; done`
+        - `for i in {0000..1273}; do aria2c -x 16 https://huggingface.co/datasets/laion/laion1b-nolang-vit-h-14-embeddings/resolve/main/metadata/metadata_$i.parquet -o $i.parquet; done`
         - `cd ..`
-6.1 Convert file to parquet
-   - `find multi-embeddings/ -type f -exec '{}' '{}'.parquet \;`
-   - `find en-embeddings/ -type f -exec '{}' '{}'.parquet \;`
-   - `find nolang-embeddings/ -type f -exec '{}' '{}'.parquet \;`
 
 7. Now run the metadata combiner for each of the metadata folders
 

--- a/docs/laion5B_h14_back.md
+++ b/docs/laion5B_h14_back.md
@@ -1,6 +1,6 @@
 # How to setup clip-back with an H/14 index of Laion5B
 
-1. Create a python virtual environment & install huggingface-cli & clip-retrieval
+1. Create a python virtual environment & install huggingface_hub & clip-retrieval
    - `pip install huggingface-cli clip-retrieval`
 2. Install `aria2` on your system
    https://github.com/aria2/aria2
@@ -11,7 +11,7 @@
    - `for i in {00..79}; do aria2c -x 16 https://huggingface.co/datasets/laion/laion5b-h14-index/resolve/main/index-parts/$i.index; done`
    - `cd ..`
 5. Combine the index parts using the following command
-   - `clip_retrieval index_combiner --input_folder "index-parts" --output_folder "combined-indices"`
+   - `clip-retrieval index_combiner --input_folder "index-parts" --output_folder "combined-indices"`
 6. Now download the metadata parts from the following metadata repos
 
    - ***multi embeddings***
@@ -20,7 +20,7 @@
         - `cd ..`
    - ***english embeddings***
         - `mkdir en-embeddings && cd en-embeddings`
-        - `for i in {0000..2314}; do aria2c -x 16 https://huggingface.co/datasets/laion/laion2b-en-vit-h-14-embeddings/resolve/main/metadata/metadata_$i.parquet; done`
+        - `for i in {0000..2313}; do aria2c -x 16 https://huggingface.co/datasets/laion/laion2b-en-vit-h-14-embeddings/resolve/main/metadata/metadata_$i.parquet; done`
         - `cd ..`
    - ***nolang embeddings***
         - `mkdir nolang-embeddings && nolang en-embeddings`

--- a/docs/laion5B_h14_back.md
+++ b/docs/laion5B_h14_back.md
@@ -40,9 +40,9 @@
    - `mkdir Laion5B_H14 && mkdir Laion5B_H14/metadata && mkdir Laion5B_H14/image.index`
 9. Move all of the metadata `arrow files` to the metadata subfolder of our new parent folder
    > **NOTE: in order to maintain the proper ordering, it is important to use the following file names**
-   - `mv en-embeddings/0.arrow Laion5B_H14/metadata/0_en.arrow`
-   - `mv multi-embeddings/0.arrow Laion5B_H14/metadata/1_multi.arrow`
-   - `mv nolang-embeddings/0.arrow Laion5B_H14/metadata/2_nolang.arrow`
+   - `mv en-combined/0.arrow Laion5B_H14/metadata/0_en.arrow`
+   - `mv multi-combined/0.arrow Laion5B_H14/metadata/1_multi.arrow`
+   - `mv nolang-combined/0.arrow Laion5B_H14/metadata/2_nolang.arrow`
 10. Move the files generated from the index combination step into the `image.index` subfolder
     - `mv combined-indices/* Laion5B_H14/image.index/`
 11. Create an indices.json file with the following (edit as necessary, more info on parameters in the [Main README](https://github.com/rom1504/clip-retrieval#clip-back))

--- a/docs/laion5B_h14_back.md
+++ b/docs/laion5B_h14_back.md
@@ -44,7 +44,7 @@
    - `mv multi-embeddings/0.arrow Laion5B_H14/metadata/1_multi.arrow`
    - `mv nolang-embeddings/0.arrow Laion5B_H14/metadata/2_nolang.arrow`
 10. Move the files generated from the index combination step into the `image.index` subfolder
-    - `mv combined-indices/* Laion5B_H14/image.index/*`
+    - `mv combined-indices/* Laion5B_H14/image.index/`
 11. Create an indices.json file with the following (edit as necessary, more info on parameters in the [Main README](https://github.com/rom1504/clip-retrieval#clip-back))
 
 ```

--- a/docs/laion5B_h14_back.md
+++ b/docs/laion5B_h14_back.md
@@ -1,7 +1,7 @@
 # How to setup clip-back with an H/14 index of Laion5B
 
 1. Create a python virtual environment & install huggingface_hub & clip-retrieval
-   - `pip install huggingface-cli clip-retrieval`
+   - `pip install huggingface_hub clip-retrieval`
 2. Install `aria2` on your system
    https://github.com/aria2/aria2
 3. Navigate to your large storage

--- a/docs/laion5B_h14_back.md
+++ b/docs/laion5B_h14_back.md
@@ -26,6 +26,10 @@
         - `mkdir nolang-embeddings && nolang en-embeddings`
         - `for i in {0000..1273}; do aria2c -x 16 https://huggingface.co/datasets/laion/laion1b-nolang-vit-h-14-embeddings/resolve/main/metadata/metadata_$i.parquet; done`
         - `cd ..`
+6.1 Convert file to parquet
+   - `find multi-embeddings/ -type f -exec '{}' '{}'.parquet \;`
+   - `find en-embeddings/ -type f -exec '{}' '{}'.parquet \;`
+   - `find nolang-embeddings/ -type f -exec '{}' '{}'.parquet \;`
 
 7. Now run the metadata combiner for each of the metadata folders
 


### PR DESCRIPTION
Fixing https://github.com/rom1504/clip-retrieval/issues/288 and https://github.com/rom1504/clip-retrieval/issues/286

Updated documentation for H14 index setup:

- aria2c command saving parquet files
- other typos