### PR TITLE
Add support for the full open clip model name format : ViT-B-32/laion2b_s34b_b79k

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ clip_inference turn a set of text+image into clip embeddings
 * **write_batch_size** Write batch size (default *10**6*)
 * **wds_image_key** Key to use for images in webdataset. (default *jpg*)
 * **wds_caption_key** Key to use for captions in webdataset. (default *txt*)
-* **clip_model** CLIP model to load (default *ViT-B/32*). Specify it as `"open_clip:ViT-B-32-quickgelu"` to use the [open_clip](https://github.com/mlfoundations/open_clip) or `"hf_clip:patrickjohncyh/fashion-clip"` to use the [hugging face](https://huggingface.co/docs/transformers/model_doc/clip) clip model.
+* **clip_model** CLIP model to load (default *ViT-B/32*). Specify it as `"open_clip:ViT-B-32/laion2b_s34b_b79k"` to use the [open_clip](https://github.com/mlfoundations/open_clip) or `"hf_clip:patrickjohncyh/fashion-clip"` to use the [hugging face](https://huggingface.co/docs/transformers/model_doc/clip) clip model.
 * **mclip_model** MCLIP model to load (default *sentence-transformers/clip-ViT-B-32-multilingual-v1*)
 * **use_mclip** If False it performs the inference using CLIP; MCLIP otherwise (default *False*)
 * **use_jit** uses jit for the clip model (default *True*)
@@ -183,7 +183,7 @@ clip_inference turn a set of text+image into clip embeddings
 * **slurm_partition** (default *None*), the slurm partition to create a job in.
 * **slurm_jobs**, the number of jobs to create in slurm. (default *None*)
 * **slurm_job_comment**, the job comment to use. (default *None*)
-* **slurm_nodelist**, a list of specific nodes to use .(default *None*
+* **slurm_nodelist**, a list of specific nodes to use .(default *None*)
 * **slurm_exclude**, a list of nodes to exclude when creating jobs. (default *None*)
 * **slurm_job_timeout**, if not supplied it will default to 2 weeks. (default *None*)
 * **slurm_cache_path**, cache path to use for slurm-related tasks. (default *None*)

--- a/clip_retrieval/clip_inference/main.py
+++ b/clip_retrieval/clip_inference/main.py
@@ -80,6 +80,7 @@ def main(
     wds_image_key="jpg",
     wds_caption_key="txt",
     clip_model="ViT-B/32",
+    clip_checkpoint=None,
     mclip_model="sentence-transformers/clip-ViT-B-32-multilingual-v1",
     use_mclip=False,
     use_jit=False,

--- a/clip_retrieval/clip_inference/main.py
+++ b/clip_retrieval/clip_inference/main.py
@@ -80,7 +80,6 @@ def main(
     wds_image_key="jpg",
     wds_caption_key="txt",
     clip_model="ViT-B/32",
-    clip_checkpoint=None,
     mclip_model="sentence-transformers/clip-ViT-B-32-multilingual-v1",
     use_mclip=False,
     use_jit=False,

--- a/clip_retrieval/clip_inference/mapper.py
+++ b/clip_retrieval/clip_inference/mapper.py
@@ -35,7 +35,8 @@ class ClipMapper:
         self.use_mclip = use_mclip
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         model, _ = load_clip(
-            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=warmup_batch_size, clip_cache_path=clip_cache_path, checkpoint=checkpoint,
+            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=warmup_batch_size, 
+            clip_cache_path=clip_cache_path, checkpoint=checkpoint,
         )
         self.model_img = model.encode_image
         self.model_txt = model.encode_text

--- a/clip_retrieval/clip_inference/mapper.py
+++ b/clip_retrieval/clip_inference/mapper.py
@@ -27,7 +27,6 @@ class ClipMapper:
         mclip_model,
         warmup_batch_size=1,
         clip_cache_path=None,
-        checkpoint=None,
     ):
         self.enable_image = enable_image
         self.enable_text = enable_text

--- a/clip_retrieval/clip_inference/mapper.py
+++ b/clip_retrieval/clip_inference/mapper.py
@@ -35,8 +35,11 @@ class ClipMapper:
         self.use_mclip = use_mclip
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         model, _ = load_clip(
-            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=warmup_batch_size,
-            clip_cache_path=clip_cache_path, checkpoint=checkpoint,
+            clip_model=clip_model,
+            use_jit=use_jit,
+            warmup_batch_size=warmup_batch_size,
+            clip_cache_path=clip_cache_path,
+            checkpoint=checkpoint,
         )
         self.model_img = model.encode_image
         self.model_txt = model.encode_text

--- a/clip_retrieval/clip_inference/mapper.py
+++ b/clip_retrieval/clip_inference/mapper.py
@@ -27,6 +27,7 @@ class ClipMapper:
         mclip_model,
         warmup_batch_size=1,
         clip_cache_path=None,
+        checkpoint=None,
     ):
         self.enable_image = enable_image
         self.enable_text = enable_text
@@ -34,7 +35,7 @@ class ClipMapper:
         self.use_mclip = use_mclip
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         model, _ = load_clip(
-            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=warmup_batch_size, clip_cache_path=clip_cache_path
+            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=warmup_batch_size, clip_cache_path=clip_cache_path, checkpoint=checkpoint,
         )
         self.model_img = model.encode_image
         self.model_txt = model.encode_text

--- a/clip_retrieval/clip_inference/mapper.py
+++ b/clip_retrieval/clip_inference/mapper.py
@@ -35,7 +35,7 @@ class ClipMapper:
         self.use_mclip = use_mclip
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         model, _ = load_clip(
-            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=warmup_batch_size, 
+            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=warmup_batch_size,
             clip_cache_path=clip_cache_path, checkpoint=checkpoint,
         )
         self.model_img = model.encode_image

--- a/clip_retrieval/clip_inference/mapper.py
+++ b/clip_retrieval/clip_inference/mapper.py
@@ -39,7 +39,6 @@ class ClipMapper:
             use_jit=use_jit,
             warmup_batch_size=warmup_batch_size,
             clip_cache_path=clip_cache_path,
-            checkpoint=checkpoint,
         )
         self.model_img = model.encode_image
         self.model_txt = model.encode_text

--- a/clip_retrieval/clip_inference/worker.py
+++ b/clip_retrieval/clip_inference/worker.py
@@ -34,7 +34,6 @@ def worker(
     wds_image_key="jpg",
     wds_caption_key="txt",
     clip_model="ViT-B/32",
-    clip_checkpoint=None,
     mclip_model="sentence-transformers/clip-ViT-B-32-multilingual-v1",
     use_mclip=False,
     use_jit=True,
@@ -55,7 +54,6 @@ def worker(
             use_jit=use_jit,
             warmup_batch_size=batch_size,
             clip_cache_path=clip_cache_path,
-            checkpoint=clip_checkpoint,
         )
         if input_format == "files":
             return FilesReader(
@@ -96,7 +94,6 @@ def worker(
             mclip_model=mclip_model,
             clip_cache_path=clip_cache_path,
             warmup_batch_size=batch_size,
-            checkpoint=clip_checkpoint,
         )
 
     def writer_builder(i):

--- a/clip_retrieval/clip_inference/worker.py
+++ b/clip_retrieval/clip_inference/worker.py
@@ -51,8 +51,11 @@ def worker(
 
     def reader_builder(sampler):
         _, preprocess = load_clip(
-            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=batch_size,
-            clip_cache_path=clip_cache_path, checkpoint=clip_checkpoint,
+            clip_model=clip_model,
+            use_jit=use_jit,
+            warmup_batch_size=batch_size,
+            clip_cache_path=clip_cache_path,
+            checkpoint=clip_checkpoint,
         )
         if input_format == "files":
             return FilesReader(

--- a/clip_retrieval/clip_inference/worker.py
+++ b/clip_retrieval/clip_inference/worker.py
@@ -51,7 +51,7 @@ def worker(
 
     def reader_builder(sampler):
         _, preprocess = load_clip(
-            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=batch_size, 
+            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=batch_size,
             clip_cache_path=clip_cache_path, checkpoint=clip_checkpoint,
         )
         if input_format == "files":

--- a/clip_retrieval/clip_inference/worker.py
+++ b/clip_retrieval/clip_inference/worker.py
@@ -34,6 +34,7 @@ def worker(
     wds_image_key="jpg",
     wds_caption_key="txt",
     clip_model="ViT-B/32",
+    clip_checkpoint=None,
     mclip_model="sentence-transformers/clip-ViT-B-32-multilingual-v1",
     use_mclip=False,
     use_jit=True,
@@ -50,7 +51,7 @@ def worker(
 
     def reader_builder(sampler):
         _, preprocess = load_clip(
-            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=batch_size, clip_cache_path=clip_cache_path
+            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=batch_size, clip_cache_path=clip_cache_path, checkpoint=clip_checkpoint,
         )
         if input_format == "files":
             return FilesReader(
@@ -91,6 +92,7 @@ def worker(
             mclip_model=mclip_model,
             clip_cache_path=clip_cache_path,
             warmup_batch_size=batch_size,
+            checkpoint=clip_checkpoint,
         )
 
     def writer_builder(i):

--- a/clip_retrieval/clip_inference/worker.py
+++ b/clip_retrieval/clip_inference/worker.py
@@ -51,7 +51,8 @@ def worker(
 
     def reader_builder(sampler):
         _, preprocess = load_clip(
-            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=batch_size, clip_cache_path=clip_cache_path, checkpoint=clip_checkpoint,
+            clip_model=clip_model, use_jit=use_jit, warmup_batch_size=batch_size, 
+            clip_cache_path=clip_cache_path, checkpoint=clip_checkpoint,
         )
         if input_format == "files":
             return FilesReader(

--- a/clip_retrieval/load_clip.py
+++ b/clip_retrieval/load_clip.py
@@ -50,9 +50,7 @@ class OpenClipWrapper(nn.Module):
         if self.device.type == "cpu":
             self.dtype = torch.float32
         else:
-            self.dtype = (
-                torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
-            )
+            self.dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
 
     def encode_image(self, image):
         if self.device.type == "cpu":
@@ -92,9 +90,7 @@ def load_hf_clip(clip_model, device="cuda"):
     return model, lambda x: preprocess(x, return_tensors="pt").pixel_values
 
 
-def load_open_clip(
-    clip_model, use_jit=True, device="cuda", clip_cache_path=None, checkpoint=None
-):
+def load_open_clip(clip_model, use_jit=True, device="cuda", clip_cache_path=None, checkpoint=None):
     """load open clip"""
 
     import open_clip  # pylint: disable=import-outside-toplevel
@@ -203,15 +199,11 @@ def get_tokenizer(clip_model):
 
 
 @lru_cache(maxsize=None)
-def load_clip_without_warmup(
-    clip_model, use_jit, device, clip_cache_path, checkpoint=None
-):
+def load_clip_without_warmup(clip_model, use_jit, device, clip_cache_path, checkpoint=None):
     """Load clip"""
     if clip_model.startswith("open_clip:"):
         clip_model = clip_model[len("open_clip:") :]
-        model, preprocess = load_open_clip(
-            clip_model, use_jit, device, clip_cache_path, checkpoint=checkpoint
-        )
+        model, preprocess = load_open_clip(clip_model, use_jit, device, clip_cache_path, checkpoint=checkpoint)
     elif clip_model.startswith("hf_clip:"):
         clip_model = clip_model[len("hf_clip:") :]
         model, preprocess = load_hf_clip(clip_model, device)
@@ -219,9 +211,7 @@ def load_clip_without_warmup(
         clip_model = clip_model[len("nm:") :]
         model, preprocess = load_deepsparse(clip_model)
     else:
-        model, preprocess = clip.load(
-            clip_model, device=device, jit=use_jit, download_root=clip_cache_path
-        )
+        model, preprocess = clip.load(clip_model, device=device, jit=use_jit, download_root=clip_cache_path)
     return model, preprocess
 
 
@@ -237,9 +227,7 @@ def load_clip(
     """Load clip then warmup"""
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
-    model, preprocess = load_clip_without_warmup(
-        clip_model, use_jit, device, clip_cache_path, checkpoint=checkpoint
-    )
+    model, preprocess = load_clip_without_warmup(clip_model, use_jit, device, clip_cache_path, checkpoint=checkpoint)
 
     start = time.time()
     print(f"warming up with batch size {warmup_batch_size} on {device}", flush=True)
@@ -252,9 +240,7 @@ def load_clip(
 def warmup(batch_size, device, preprocess, model):
     fake_img = Image.new("RGB", (224, 224), color="red")
     fake_text = ["fake"] * batch_size
-    image_tensor = torch.cat(
-        [torch.unsqueeze(preprocess(fake_img), 0)] * batch_size
-    ).to(device)
+    image_tensor = torch.cat([torch.unsqueeze(preprocess(fake_img), 0)] * batch_size).to(device)
     text_tokens = clip.tokenize(fake_text).to(device)
     for _ in range(2):
         with torch.no_grad():

--- a/clip_retrieval/load_clip.py
+++ b/clip_retrieval/load_clip.py
@@ -96,7 +96,6 @@ def load_open_clip(clip_model, use_jit=True, device="cuda", clip_cache_path=None
     import open_clip  # pylint: disable=import-outside-toplevel
 
     torch.backends.cuda.matmul.allow_tf32 = True
-    
     if checkpoint is None:
         pretrained = dict(open_clip.list_pretrained())
         checkpoint = pretrained[clip_model]
@@ -213,7 +212,10 @@ def load_clip_without_warmup(clip_model, use_jit, device, clip_cache_path, check
 
 
 @lru_cache(maxsize=None)
-def load_clip(clip_model="ViT-B/32", use_jit=True, warmup_batch_size=1, clip_cache_path=None, device=None, checkpoint=None):
+def load_clip(
+    clip_model="ViT-B/32", use_jit=True, warmup_batch_size=1, 
+    clip_cache_path=None, device=None, checkpoint=None
+):
     """Load clip then warmup"""
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/clip_retrieval/load_clip.py
+++ b/clip_retrieval/load_clip.py
@@ -79,15 +79,27 @@ def load_hf_clip(clip_model, device="cuda"):
     return model, lambda x: preprocess(x, return_tensors="pt").pixel_values
 
 
-def load_open_clip(clip_model, use_jit=True, device="cuda", clip_cache_path=None):
+def load_hf_clip(clip_model, device="cuda"):
+    """load hf clip"""
+    from transformers import CLIPProcessor, CLIPModel  # pylint: disable=import-outside-toplevel
+
+    model = CLIPModel.from_pretrained(clip_model)
+    preprocess = CLIPProcessor.from_pretrained(clip_model).image_processor
+    model = HFClipWrapper(inner_model=model, device=device)
+    model.to(device=device)
+    return model, lambda x: preprocess(x, return_tensors="pt").pixel_values
+
+
+def load_open_clip(clip_model, use_jit=True, device="cuda", clip_cache_path=None, checkpoint=None):
     """load open clip"""
 
     import open_clip  # pylint: disable=import-outside-toplevel
 
     torch.backends.cuda.matmul.allow_tf32 = True
-
-    pretrained = dict(open_clip.list_pretrained())
-    checkpoint = pretrained[clip_model]
+    
+    if checkpoint is None:
+        pretrained = dict(open_clip.list_pretrained())
+        checkpoint = pretrained[clip_model]
     model, _, preprocess = open_clip.create_model_and_transforms(
         clip_model, pretrained=checkpoint, device=device, jit=use_jit, cache_dir=clip_cache_path
     )
@@ -184,11 +196,11 @@ def get_tokenizer(clip_model):
 
 
 @lru_cache(maxsize=None)
-def load_clip_without_warmup(clip_model, use_jit, device, clip_cache_path):
+def load_clip_without_warmup(clip_model, use_jit, device, clip_cache_path, checkpoint=None):
     """Load clip"""
     if clip_model.startswith("open_clip:"):
         clip_model = clip_model[len("open_clip:") :]
-        model, preprocess = load_open_clip(clip_model, use_jit, device, clip_cache_path)
+        model, preprocess = load_open_clip(clip_model, use_jit, device, clip_cache_path, checkpoint=checkpoint)
     elif clip_model.startswith("hf_clip:"):
         clip_model = clip_model[len("hf_clip:") :]
         model, preprocess = load_hf_clip(clip_model, device)
@@ -201,11 +213,11 @@ def load_clip_without_warmup(clip_model, use_jit, device, clip_cache_path):
 
 
 @lru_cache(maxsize=None)
-def load_clip(clip_model="ViT-B/32", use_jit=True, warmup_batch_size=1, clip_cache_path=None, device=None):
+def load_clip(clip_model="ViT-B/32", use_jit=True, warmup_batch_size=1, clip_cache_path=None, device=None, checkpoint=None):
     """Load clip then warmup"""
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
-    model, preprocess = load_clip_without_warmup(clip_model, use_jit, device, clip_cache_path)
+    model, preprocess = load_clip_without_warmup(clip_model, use_jit, device, clip_cache_path, checkpoint=checkpoint)
 
     start = time.time()
     print(f"warming up with batch size {warmup_batch_size} on {device}", flush=True)

--- a/clip_retrieval/load_clip.py
+++ b/clip_retrieval/load_clip.py
@@ -79,17 +79,6 @@ def load_hf_clip(clip_model, device="cuda"):
     return model, lambda x: preprocess(x, return_tensors="pt").pixel_values
 
 
-def load_hf_clip(clip_model, device="cuda"):
-    """load hf clip"""
-    from transformers import CLIPProcessor, CLIPModel  # pylint: disable=import-outside-toplevel
-
-    model = CLIPModel.from_pretrained(clip_model)
-    preprocess = CLIPProcessor.from_pretrained(clip_model).image_processor
-    model = HFClipWrapper(inner_model=model, device=device)
-    model.to(device=device)
-    return model, lambda x: preprocess(x, return_tensors="pt").pixel_values
-
-
 def load_open_clip(clip_model, use_jit=True, device="cuda", clip_cache_path=None):
     """load open clip"""
 

--- a/clip_retrieval/load_clip.py
+++ b/clip_retrieval/load_clip.py
@@ -213,7 +213,7 @@ def load_clip_without_warmup(clip_model, use_jit, device, clip_cache_path, check
 
 @lru_cache(maxsize=None)
 def load_clip(
-    clip_model="ViT-B/32", use_jit=True, warmup_batch_size=1, 
+    clip_model="ViT-B/32", use_jit=True, warmup_batch_size=1,
     clip_cache_path=None, device=None, checkpoint=None
 ):
     """Load clip then warmup"""

--- a/tests/test_clip_inference/test_mapper.py
+++ b/tests/test_clip_inference/test_mapper.py
@@ -10,7 +10,7 @@ from clip_retrieval.clip_inference.mapper import ClipMapper
     "model",
     [
         "ViT-B/32",
-        "open_clip:ViT-B-32-quickgelu",
+        "open_clip:ViT-B-32/laion2b_s34b_b79k",
         "hf_clip:patrickjohncyh/fashion-clip",
         "nm:mgoin/CLIP-ViT-B-32-laion2b_s34b_b79k-ds",
     ],


### PR DESCRIPTION
This leaves the defaults the same, but allow the possibility to specify a checkpoint if needed (i.e, corresponds to the `pretrained` parameter of open clip).


