### PR TITLE
Add DeepSparse backend for CLIP inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ clip_inference turn a set of text+image into clip embeddings
 * **slurm_cache_path**, cache path to use for slurm-related tasks. (default *None*)
 * **slurm_verbose_wait=False**, wether to print the status of your slurm job (default *False*)
 
+#### DeepSparse Backend
+
+[DeepSparse](https://github.com/neuralmagic/deepsparse) is an inference runtime for fast sparse model inference on CPUs. There is a backend available within clip-retrieval by installing it with `pip install deepsparse-nightly[clip]`, and specifying a `clip_model` with a prepended `"nm:"`, such as [`"nm:neuralmagic/CLIP-ViT-B-32-256x256-DataComp-s34B-b86K-quant-ds"`](https://huggingface.co/neuralmagic/CLIP-ViT-B-32-256x256-DataComp-s34B-b86K-quant-ds) or [`"nm:mgoin/CLIP-ViT-B-32-laion2b_s34b_b79k-ds"`](https://huggingface.co/mgoin/CLIP-ViT-B-32-laion2b_s34b_b79k-ds).
+
 ### Inference Worker
 
 If you wish to have more control over how inference is run, you can create and call workers directly using `clip-retrieval inference.worker`

--- a/clip_retrieval/load_clip.py
+++ b/clip_retrieval/load_clip.py
@@ -5,7 +5,7 @@ import torch
 import clip
 from PIL import Image
 import time
-
+import numpy as np
 
 class HFClipWrapper(nn.Module):
     """
@@ -95,6 +95,79 @@ def load_open_clip(clip_model, use_jit=True, device="cuda", clip_cache_path=None
     return model, preprocess
 
 
+
+class DeepSparseWrapper(nn.Module):
+    """
+    Wrap DeepSparse for managing input types
+    """
+
+    def __init__(self, model_path):
+        super().__init__()
+
+        import deepsparse
+
+        ##### Fix for two-input model
+        from deepsparse.clip import CLIPTextPipeline
+
+        def custom_process_inputs(self, inputs):
+            if not isinstance(inputs.text, list):
+                inputs.text = [inputs.text]
+            if not isinstance(inputs.text[0], str):
+                return inputs.text
+            tokens = [np.array(t).astype(np.int32) for t in self.tokenizer(inputs.text)]
+            tokens = np.stack(tokens, axis=0)
+            tokens_lengths = np.array(tokens.shape[0] * [tokens.shape[1] - 1])
+            return [tokens, tokens_lengths]
+
+        # This overrides the process_inputs function globally for all CLIPTextPipeline classes
+        CLIPTextPipeline.process_inputs = custom_process_inputs
+        ####
+
+        self.textual_model_path = model_path + "/textual.onnx"
+        self.visual_model_path = model_path + "/visual.onnx"
+
+        self.textual_model = deepsparse.Pipeline(task="clip_text", model_path=self.textual_model_path)
+        self.visual_model = deepsparse.Pipeline(task="clip_visual", model_path=self.visual_model_path)
+
+    def encode_image(self, image):
+        return self.visual_model(images=image).image_embeddings[0]
+
+    def encode_text(self, text):
+        return self.textual_model(text=text).text_embeddings[0]
+
+    def forward(self, *args, **kwargs):
+        return NotImplemented
+
+
+def load_deepsparse(clip_model):
+    """load deepsparse"""
+
+    from huggingface_hub import snapshot_download
+
+    # Download the model from HF
+    model_folder = snapshot_download(repo_id=clip_model)
+    # Compile the model with DeepSparse
+    model = DeepSparseWrapper(model_path=model_folder)
+
+    from deepsparse.clip.constants import CLIP_RGB_MEANS, CLIP_RGB_STDS
+
+    def process_image(image):
+        image = image.convert("RGB")
+        image = model.visual_model._preprocess_transforms(image)
+        image_array = np.array(image)
+
+        # make channel dim the first dim
+        image_array = image_array.transpose(2, 0, 1).astype("float32")
+
+        image_array /= 255.0
+        image_array = (
+            image_array - np.array(CLIP_RGB_MEANS).reshape((3, 1, 1))
+        ) / np.array(CLIP_RGB_STDS).reshape((3, 1, 1))
+        return np.ascontiguousarray(image_array, dtype=np.float32)
+
+    return model, process_image
+
+
 @lru_cache(maxsize=None)
 def get_tokenizer(clip_model):
     """Load clip"""
@@ -116,6 +189,9 @@ def load_clip_without_warmup(clip_model, use_jit, device, clip_cache_path):
     elif clip_model.startswith("hf_clip:"):
         clip_model = clip_model[len("hf_clip:") :]
         model, preprocess = load_hf_clip(clip_model, device)
+    elif clip_model.startswith("nm:"):
+        clip_model = clip_model[len("nm:") :]
+        model, preprocess = load_deepsparse(clip_model)
     else:
         model, preprocess = clip.load(clip_model, device=device, jit=use_jit, download_root=clip_cache_path)
     return model, preprocess

--- a/clip_retrieval/load_clip.py
+++ b/clip_retrieval/load_clip.py
@@ -107,7 +107,7 @@ class DeepSparseWrapper(nn.Module):
         import deepsparse # pylint: disable=import-outside-toplevel
 
         ##### Fix for two-input models
-        from deepsparse.clip import CLIPTextPipeline
+        from deepsparse.clip import CLIPTextPipeline # pylint: disable=import-outside-toplevel
 
         def custom_process_inputs(self, inputs):
             if not isinstance(inputs.text, list):
@@ -142,7 +142,7 @@ class DeepSparseWrapper(nn.Module):
         embeddings = self.textual_model(text=text).text_embeddings[0]
         return torch.from_numpy(embeddings)
 
-    def forward(self, *args, **kwargs):
+    def forward(self, *args, **kwargs): # pylint: disable=unused-argument
         return NotImplemented
 
 
@@ -156,10 +156,10 @@ def load_deepsparse(clip_model):
     # Compile the model with DeepSparse
     model = DeepSparseWrapper(model_path=model_folder)
 
-    from deepsparse.clip.constants import CLIP_RGB_MEANS, CLIP_RGB_STDS
+    from deepsparse.clip.constants import CLIP_RGB_MEANS, CLIP_RGB_STDS # pylint: disable=import-outside-toplevel
 
     def process_image(image):
-        image = model.visual_model._preprocess_transforms(image.convert("RGB"))
+        image = model.visual_model._preprocess_transforms(image.convert("RGB")) # pylint: disable=protected-access
         image_array = np.array(image)
         image_array = image_array.transpose(2, 0, 1).astype("float32")
         image_array /= 255.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,3 +9,4 @@ types-setuptools
 types-requests
 types-certifi
 pyspark
+deepsparse-nightly[clip]

--- a/tests/test_clip_inference/test_mapper.py
+++ b/tests/test_clip_inference/test_mapper.py
@@ -11,7 +11,7 @@ from clip_retrieval.clip_inference.mapper import ClipMapper
     [
         "ViT-B/32",
         "open_clip:ViT-B-32-quickgelu", "hf_clip:patrickjohncyh/fashion-clip",
-        "nm:neuralmagic/CLIP-ViT-B-32-256x256-DataComp-s34B-b86K-quant-ds",
+        "nm:mgoin/CLIP-ViT-B-32-laion2b_s34b_b79k-ds",
     ],
 )
 def test_mapper(model):

--- a/tests/test_clip_inference/test_mapper.py
+++ b/tests/test_clip_inference/test_mapper.py
@@ -10,7 +10,8 @@ from clip_retrieval.clip_inference.mapper import ClipMapper
     "model",
     [
         "ViT-B/32",
-        "open_clip:ViT-B-32-quickgelu", "hf_clip:patrickjohncyh/fashion-clip",
+        "open_clip:ViT-B-32-quickgelu",
+        "hf_clip:patrickjohncyh/fashion-clip",
         "nm:mgoin/CLIP-ViT-B-32-laion2b_s34b_b79k-ds",
     ],
 )

--- a/tests/test_clip_inference/test_mapper.py
+++ b/tests/test_clip_inference/test_mapper.py
@@ -6,7 +6,14 @@ import numpy as np
 from clip_retrieval.clip_inference.mapper import ClipMapper
 
 
-@pytest.mark.parametrize("model", ["ViT-B/32", "open_clip:ViT-B-32-quickgelu", "hf_clip:patrickjohncyh/fashion-clip"])
+@pytest.mark.parametrize(
+    "model",
+    [
+        "ViT-B/32",
+        "open_clip:ViT-B-32-quickgelu", "hf_clip:patrickjohncyh/fashion-clip",
+        "nm:neuralmagic/CLIP-ViT-B-32-256x256-DataComp-s34B-b86K-quant-ds",
+    ],
+)
 def test_mapper(model):
     os.environ["CUDA_VISIBLE_DEVICES"] = ""
 


### PR DESCRIPTION
[DeepSparse](https://github.com/neuralmagic/deepsparse) is an inference runtime for fast sparse model inference on CPUs. 
There is a backend available within clip-retrieval by installing it with `pip install deepsparse-nightly[clip]`, and specifying a `clip_model` with a prepended `"nm:"`, such as [`"nm:neuralmagic/CLIP-ViT-B-32-256x256-DataComp-s34B-b86K-quant-ds"`](https://huggingface.co/neuralmagic/CLIP-ViT-B-32-256x256-DataComp-s34B-b86K-quant-ds) or [`"nm:mgoin/CLIP-ViT-B-32-laion2b_s34b_b79k-ds"`](https://huggingface.co/mgoin/CLIP-ViT-B-32-laion2b_s34b_b79k-ds).


## Install
```
git clone https://github.com/mgoin/clip-retrieval
cd clip-retrieval 
git checkout deepsparse-clip-backend 
pip install -e . 
pip install "deepsparse-nightly[clip]"
```

## Setup some example images
```
pip install img2dataset
echo 'https://placekitten.com/200/305' >> myimglist.txt
echo 'https://placekitten.com/200/304' >> myimglist.txt
echo 'https://placekitten.com/200/303' >> myimglist.txt
img2dataset --url_list=myimglist.txt --output_folder=image_folder --thread_count=64 --image_size=256
```

## Inference!
```
clip-retrieval inference --batch_size 4 --clip_model=nm:neuralmagic/CLIP-ViT-B-32-256x256-DataComp-s34B-b86K-quant-ds --input_dataset image_folder --output_folder embeddings_folder
The number of samples has been estimated to be 3
Starting the worker
dataset is 12
Starting work on task 0
Fetching 7 files: 100%|███████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00, 61422.86it/s]
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.7.0.20231210 COMMUNITY | (99472380) (release) (optimized) (system=avx512_vnni, binary=avx512)
warming up with batch size 4 on cpu
done warming up in 0.5746381282806396s
 sample_per_sec 0 ; sample_count 3 
 ```