### PR TITLE
Update prefetch_factor in clip_inference/reader.py

### DIFF
--- a/clip_retrieval/clip_inference/reader.py
+++ b/clip_retrieval/clip_inference/reader.py
@@ -194,7 +194,7 @@ def dataset_to_dataloader(dataset, batch_size, num_prepro_workers, input_format)
         shuffle=False,
         num_workers=num_prepro_workers,
         pin_memory=True,
-        prefetch_factor=2,
+        prefetch_factor=2 if num_prepro_workers>0 else None,
         collate_fn=collate_fn if input_format == "files" else None,
     )
     return data


### PR DESCRIPTION
Sets prefetch_factor to None when there's no multiprocessing, as in [torch dataloader](https://github.com/pytorch/pytorch/blob/74f4947caf2119adef35dd2ecaa67376c631195c/torch/utils/data/dataloader.py#L245) since [Nov 2022](https://github.com/pytorch/pytorch/pull/88972)

