### PR TITLE
[requirements.txt] Loosen dependencies related to networking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,10 +19,9 @@ fsspec
 sentence-transformers>=2.2.0,<3
 wandb>=0.12.0,<0.17
 open-clip-torch>=2.0.0,<3.0.0
-requests>=2.27.1,<3
-aiohttp>=3.8.1,<4
+requests>=2.27.1
+aiohttp>=3.8.1
 multilingual-clip>=1.0.10,<2
 transformers
-urllib3<2
 scipy<1.13
 all_clip<2


### PR DESCRIPTION
Getting this error:
```
INFO: pip is looking at multiple versions of gradio to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements.txt (line 25) and -r requirements.txt (line 67) because these package versions have conflicting dependencies.

The conflict is caused by:
    clip-retrieval 2.44.0 depends on urllib3<2
    gradio 4.44.1 depends on urllib3~=2.0
```

I was trying to figure out where you are using urllib3, and why you are restricting to that old version.

requests and aiohttp are the only candidates which obviously come to mind; if the tests pass then accept this PR? - Might be a good idea to upgrade all deps also; resolving conflicts as this is done; happy to do that if this PR gets through :)