### PR TITLE
Bug fix, when caption and image exist at the same time

### DIFF
--- a/clip_retrieval/clip_inference/reader.py
+++ b/clip_retrieval/clip_inference/reader.py
@@ -15,7 +15,7 @@ def folder_to_keys(folder, enable_text=True, enable_image=True, enable_metadata=
     image_files = None
     if enable_text:
         text_files = [*path.glob("**/*.txt")]
-        text_files = {text_file.relative_to(path).as_posix(): text_file for text_file in text_files}
+        text_files = {text_file.relative_to(path).with_suffix("").as_posix(): text_file for text_file in text_files}
     if enable_image:
         image_files = [
             *path.glob("**/*.png"),
@@ -29,10 +29,10 @@ def folder_to_keys(folder, enable_text=True, enable_image=True, enable_metadata=
             *path.glob("**/*.BMP"),
             *path.glob("**/*.WEBP"),
         ]
-        image_files = {image_file.relative_to(path).as_posix(): image_file for image_file in image_files}
+        image_files = {image_file.relative_to(path).with_suffix("").as_posix(): image_file for image_file in image_files}
     if enable_metadata:
         metadata_files = [*path.glob("**/*.json")]
-        metadata_files = {metadata_file.relative_to(path).as_posix(): metadata_file for metadata_file in metadata_files}
+        metadata_files = {metadata_file.relative_to(path).with_suffix("").as_posix(): metadata_file for metadata_file in metadata_files}
 
     keys = None
 


### PR DESCRIPTION
The key of text is {file.txt, ...}, which leads to not found when searching by image key {file.jpg} when text and image are enabled