### PR TITLE
Fix publish condition for npm-publish v4

### DIFF
--- a/.github/workflows/front-publish.yml
+++ b/.github/workflows/front-publish.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         package: front/package.json
     - name: Create Release
-      if: steps.publish.outputs.type != 'none'
+      if: ${{ steps.publish.outputs.type }}
       id: create_release
       uses: actions/create-release@v1
       env:


### PR DESCRIPTION
## Summary
- Change `if: steps.publish.outputs.type != 'none'` to `if: ${{ steps.publish.outputs.type }}`

npm-publish v4 outputs an empty string when the version is unchanged (v1 used `none`). The old condition was always true, causing the Create Release step to run and fail on every non-release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)