### PR TITLE
Add TwelveLabs Marengo embedding backend for clip back

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ clip_inference turn a set of text+image into clip embeddings
 
 [DeepSparse](https://github.com/neuralmagic/deepsparse) is an inference runtime for fast sparse model inference on CPUs. There is a backend available within clip-retrieval by installing it with `pip install deepsparse-nightly[clip]`, and specifying a `clip_model` with a prepended `"nm:"`, such as [`"nm:neuralmagic/CLIP-ViT-B-32-256x256-DataComp-s34B-b86K-quant-ds"`](https://huggingface.co/neuralmagic/CLIP-ViT-B-32-256x256-DataComp-s34B-b86K-quant-ds) or [`"nm:mgoin/CLIP-ViT-B-32-laion2b_s34b_b79k-ds"`](https://huggingface.co/mgoin/CLIP-ViT-B-32-laion2b_s34b_b79k-ds).
 
+#### TwelveLabs Marengo Backend
+
+[Marengo](https://www.twelvelabs.io/) is a video-native multimodal embedding model from TwelveLabs that embeds text and images into the same vector space as the video segments it produces, making it a useful alternative to CLIP when your corpus is video. It is served through the TwelveLabs API rather than a local torch model. Install the optional dependency with `pip install clip-retrieval[twelvelabs]`, set the `TWELVELABS_API_KEY` environment variable (grab a free key at [twelvelabs.io](https://twelvelabs.io)), and specify a `clip_model` with a prepended `"twelvelabs:"`, such as `"twelvelabs:marengo3.0"`. Embeddings are computed via API calls, so no GPU is required on the backend. This is fully opt-in and does not affect the default CLIP behavior.
+
 ### Inference Worker
 
 If you wish to have more control over how inference is run, you can create and call workers directly using `clip-retrieval inference.worker`
@@ -315,7 +319,7 @@ clip-retrieval back --port 1234 --indices-paths indices_paths.json
 
 Options:
 * `--use_jit True` uses jit for the clip model
-* `--clip_model "ViT-B/32"` allows choosing the clip model to use. Prefix with `"open_clip:"` to use an [open_clip](https://github.com/mlfoundations/open_clip) model.
+* `--clip_model "ViT-B/32"` allows choosing the clip model to use. Prefix with `"open_clip:"` to use an [open_clip](https://github.com/mlfoundations/open_clip) model, or with `"twelvelabs:"` (e.g. `"twelvelabs:marengo3.0"`) to use the TwelveLabs Marengo backend.
 * `--enable_mclip_option True` loads the mclip model, making it possible to search in any language.
 * `--columns_to_return='["url", "image_path", "caption", "NSFW"]` allows you to specify which columns should be fetched from the metadata and returned by the backend. It's useful to specify less in case of hdf5 caching to speed up the queries.
 * `--enable_faiss_memory_mapping=True` option can be passed to use an index with memory mapping.

--- a/clip_retrieval/clip_back.py
+++ b/clip_retrieval/clip_back.py
@@ -219,7 +219,10 @@ class KnnService(Resource):
         import torch  # pylint: disable=import-outside-toplevel
 
         if text_input is not None and text_input != "":
-            if use_mclip:
+            if clip_resource.marengo_model is not None:
+                with TEXT_CLIP_INFERENCE_TIME.time():
+                    query = clip_resource.marengo_model.encode_text(text_input)
+            elif use_mclip:
                 with TEXT_CLIP_INFERENCE_TIME.time():
                     query = normalized(clip_resource.model_txt_mclip(text_input))
             else:
@@ -236,14 +239,18 @@ class KnnService(Resource):
                 img_data = BytesIO(binary_data)
             elif image_url_input is not None:
                 img_data = download_image(image_url_input)
-            with IMAGE_PREPRO_TIME.time():
-                img = Image.open(img_data)
-                prepro = clip_resource.preprocess(img).unsqueeze(0).to(clip_resource.device)
-            with IMAGE_CLIP_INFERENCE_TIME.time():
-                with torch.no_grad():
-                    image_features = clip_resource.model.encode_image(prepro)
-                image_features /= image_features.norm(dim=-1, keepdim=True)
-                query = image_features.cpu().to(torch.float32).detach().numpy()
+            if clip_resource.marengo_model is not None:
+                with IMAGE_CLIP_INFERENCE_TIME.time():
+                    query = clip_resource.marengo_model.encode_image(img_data.read())
+            else:
+                with IMAGE_PREPRO_TIME.time():
+                    img = Image.open(img_data)
+                    prepro = clip_resource.preprocess(img).unsqueeze(0).to(clip_resource.device)
+                with IMAGE_CLIP_INFERENCE_TIME.time():
+                    with torch.no_grad():
+                        image_features = clip_resource.model.encode_image(prepro)
+                    image_features /= image_features.norm(dim=-1, keepdim=True)
+                    query = image_features.cpu().to(torch.float32).detach().numpy()
         elif embedding_input is not None:
             query = np.expand_dims(np.array(embedding_input).astype("float32"), 0)
 
@@ -784,6 +791,7 @@ class ClipResource:
     columns_to_return: List[str]
     metadata_is_ordered_by_ivf: bool
     aesthetic_embeddings: Any
+    marengo_model: Any = None
 
 
 @dataclass
@@ -863,22 +871,37 @@ def load_clip_index(clip_options):
     """load the clip index"""
     import torch  # pylint: disable=import-outside-toplevel
     from all_clip import load_clip  # pylint: disable=import-outside-toplevel
+    from clip_retrieval.marengo import is_marengo_model, load_marengo  # pylint: disable=import-outside-toplevel
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    model, preprocess, tokenizer = load_clip(clip_options.clip_model, use_jit=clip_options.use_jit, device=device)
 
-    if clip_options.enable_mclip_option:
-        model_txt_mclip = load_mclip(clip_options.clip_model)
-    else:
+    # TwelveLabs Marengo is a video-native embedding API: it has no torch model, tokenizer or
+    # preprocess, and the CLIP-specific safety / violence / aesthetic / mclip helpers do not apply.
+    marengo_model = None
+    if is_marengo_model(clip_options.clip_model):
+        marengo_model = load_marengo(clip_options.clip_model)
+        model = None
+        preprocess = None
+        tokenizer = None
         model_txt_mclip = None
+        safety_model = None
+        violence_detector = None
+        aesthetic_embeddings = None
+    else:
+        model, preprocess, tokenizer = load_clip(clip_options.clip_model, use_jit=clip_options.use_jit, device=device)
 
-    safety_model = load_safety_model(clip_options.clip_model) if clip_options.provide_safety_model else None
-    violence_detector = (
-        load_violence_detector(clip_options.clip_model) if clip_options.provide_violence_detector else None
-    )
-    aesthetic_embeddings = (
-        get_aesthetic_embedding(clip_options.clip_model) if clip_options.provide_aesthetic_embeddings else None
-    )
+        if clip_options.enable_mclip_option:
+            model_txt_mclip = load_mclip(clip_options.clip_model)
+        else:
+            model_txt_mclip = None
+
+        safety_model = load_safety_model(clip_options.clip_model) if clip_options.provide_safety_model else None
+        violence_detector = (
+            load_violence_detector(clip_options.clip_model) if clip_options.provide_violence_detector else None
+        )
+        aesthetic_embeddings = (
+            get_aesthetic_embedding(clip_options.clip_model) if clip_options.provide_aesthetic_embeddings else None
+        )
 
     image_present = os.path.exists(clip_options.indice_folder + "/image.index")
     text_present = os.path.exists(clip_options.indice_folder + "/text.index")
@@ -921,6 +944,7 @@ def load_clip_index(clip_options):
         columns_to_return=clip_options.columns_to_return,
         metadata_is_ordered_by_ivf=clip_options.reorder_metadata_by_ivf_index,
         aesthetic_embeddings=aesthetic_embeddings,
+        marengo_model=marengo_model,
     )
 
 

--- a/clip_retrieval/marengo.py
+++ b/clip_retrieval/marengo.py
@@ -38,14 +38,14 @@ class MarengoModel:
     """
 
     def __init__(self, model_name=DEFAULT_MARENGO_MODEL, api_key=None):
-        from twelvelabs import TwelveLabs  # pylint: disable=import-outside-toplevel
-
         api_key = api_key or os.environ.get("TWELVELABS_API_KEY")
         if not api_key:
             raise ValueError(
                 "TwelveLabs API key not found. Set the TWELVELABS_API_KEY environment variable "
                 "or pass api_key=. Get a free key at https://twelvelabs.io"
             )
+        from twelvelabs import TwelveLabs  # pylint: disable=import-outside-toplevel
+
         self.model_name = model_name
         self._client = TwelveLabs(api_key=api_key)
 

--- a/clip_retrieval/marengo.py
+++ b/clip_retrieval/marengo.py
@@ -1,0 +1,77 @@
+"""marengo module provides TwelveLabs Marengo embeddings as an opt-in alternative to CLIP
+
+Marengo is a video-native multimodal embedding model from TwelveLabs. It embeds text and
+images into the same 512-dim space as the video segment embeddings it produces, which makes
+it a drop-in alternative to CLIP when the corpus you index is video (or a mix of video and
+images) rather than still images only.
+
+This module is only imported when a model name with the ``twelvelabs:`` prefix is requested
+(for example ``twelvelabs:marengo3.0``), so the ``twelvelabs`` SDK stays an optional dependency.
+"""
+
+import os
+
+import numpy as np
+
+MARENGO_PREFIX = "twelvelabs:"
+DEFAULT_MARENGO_MODEL = "marengo3.0"
+# Marengo embeddings are 512-dim float vectors, the same width as ViT-B/32 CLIP embeddings.
+MARENGO_DIMENSIONS = 512
+
+
+def is_marengo_model(clip_model):
+    """return True if clip_model selects a TwelveLabs Marengo model"""
+    return isinstance(clip_model, str) and clip_model.startswith(MARENGO_PREFIX)
+
+
+def marengo_model_name(clip_model):
+    """extract the TwelveLabs model name from a ``twelvelabs:<name>`` string"""
+    name = clip_model[len(MARENGO_PREFIX) :] if is_marengo_model(clip_model) else clip_model
+    return name or DEFAULT_MARENGO_MODEL
+
+
+class MarengoModel:
+    """thin wrapper around the TwelveLabs embed API exposing encode_text / encode_image
+
+    Vectors are L2-normalized to match the convention used everywhere else in clip-retrieval
+    (faiss inner-product search over unit vectors).
+    """
+
+    def __init__(self, model_name=DEFAULT_MARENGO_MODEL, api_key=None):
+        from twelvelabs import TwelveLabs  # pylint: disable=import-outside-toplevel
+
+        api_key = api_key or os.environ.get("TWELVELABS_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "TwelveLabs API key not found. Set the TWELVELABS_API_KEY environment variable "
+                "or pass api_key=. Get a free key at https://twelvelabs.io"
+            )
+        self.model_name = model_name
+        self._client = TwelveLabs(api_key=api_key)
+
+    def _normalize(self, vector):
+        vector = np.asarray(vector, dtype="float32")
+        norm = np.linalg.norm(vector)
+        if norm == 0:
+            return vector
+        return vector / norm
+
+    def encode_text(self, text):
+        """embed a single text string, returning a (1, 512) float32 numpy array"""
+        response = self._client.embed.create(model_name=self.model_name, text=text)
+        vector = response.text_embedding.segments[0].float_
+        return self._normalize(vector)[np.newaxis, :]
+
+    def encode_image(self, image_bytes):
+        """embed a single image (raw bytes), returning a (1, 512) float32 numpy array
+
+        Marengo requires images of at least 128x128 pixels.
+        """
+        response = self._client.embed.create(model_name=self.model_name, image_file=image_bytes)
+        vector = response.image_embedding.segments[0].float_
+        return self._normalize(vector)[np.newaxis, :]
+
+
+def load_marengo(clip_model, api_key=None):
+    """load a Marengo model from a ``twelvelabs:<name>`` model string"""
+    return MarengoModel(model_name=marengo_model_name(clip_model), api_key=api_key)

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
         ],
         keywords=["machine learning", "computer vision", "download", "image", "dataset"],
         install_requires=REQUIREMENTS,
+        extras_require={"twelvelabs": ["twelvelabs>=1.2.8,<2"]},
         classifiers=[
             "Development Status :: 4 - Beta",
             "Intended Audience :: Developers",

--- a/tests/test_marengo.py
+++ b/tests/test_marengo.py
@@ -1,0 +1,97 @@
+"""Test the TwelveLabs Marengo embedding backend."""
+
+import os
+import numpy as np
+import pytest
+
+from clip_retrieval.marengo import (
+    MARENGO_DIMENSIONS,
+    MarengoModel,
+    is_marengo_model,
+    load_marengo,
+    marengo_model_name,
+)
+
+
+def test_is_marengo_model():
+    assert is_marengo_model("twelvelabs:marengo3.0")
+    assert is_marengo_model("twelvelabs:")
+    assert not is_marengo_model("ViT-B/32")
+    assert not is_marengo_model("open_clip:ViT-H-14")
+    assert not is_marengo_model(None)
+
+
+def test_marengo_model_name():
+    assert marengo_model_name("twelvelabs:marengo3.0") == "marengo3.0"
+    assert marengo_model_name("twelvelabs:") == "marengo3.0"  # falls back to default
+
+
+class _FakeSegment:
+    def __init__(self, vector):
+        self.float_ = vector
+
+
+class _FakeEmbedding:
+    def __init__(self, vector):
+        self.segments = [_FakeSegment(vector)]
+
+
+class _FakeResponse:
+    def __init__(self, text=None, image=None):
+        self.text_embedding = _FakeEmbedding(text) if text is not None else None
+        self.image_embedding = _FakeEmbedding(image) if image is not None else None
+
+
+class _FakeEmbed:
+    def create(self, model_name, text=None, image_file=None):  # noqa: ARG002
+        raw = [3.0, 4.0] + [0.0] * (MARENGO_DIMENSIONS - 2)
+        if text is not None:
+            return _FakeResponse(text=raw)
+        return _FakeResponse(image=raw)
+
+
+class _FakeClient:
+    def __init__(self):
+        self.embed = _FakeEmbed()
+
+
+def _model_with_fake_client():
+    model = MarengoModel.__new__(MarengoModel)
+    model.model_name = "marengo3.0"
+    model._client = _FakeClient()  # pylint: disable=protected-access
+    return model
+
+
+def test_encode_text_shape_and_normalization():
+    model = _model_with_fake_client()
+    out = model.encode_text("a cat")
+    assert out.shape == (1, MARENGO_DIMENSIONS)
+    assert out.dtype == np.float32
+    # 3-4-0... normalized to unit length -> 0.6, 0.8
+    np.testing.assert_allclose(np.linalg.norm(out), 1.0, atol=1e-5)
+    np.testing.assert_allclose(out[0, :2], [0.6, 0.8], atol=1e-5)
+
+
+def test_encode_image_shape():
+    model = _model_with_fake_client()
+    out = model.encode_image(b"fake-image-bytes")
+    assert out.shape == (1, MARENGO_DIMENSIONS)
+    np.testing.assert_allclose(np.linalg.norm(out), 1.0, atol=1e-5)
+
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("TWELVELABS_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="TwelveLabs API key"):
+        MarengoModel(api_key=None)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TWELVELABS_API_KEY"),
+    reason="requires TWELVELABS_API_KEY for a live Marengo embedding call",
+)
+def test_live_text_embedding():
+    """Live smoke test against the TwelveLabs API (skipped when no key is set)."""
+    model = load_marengo("twelvelabs:marengo3.0")
+    out = model.encode_text("a cat playing the piano")
+    assert out.shape == (1, MARENGO_DIMENSIONS)
+    np.testing.assert_allclose(np.linalg.norm(out), 1.0, atol=1e-4)


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds

An opt-in **TwelveLabs Marengo** embedding backend for `clip-retrieval back`, alongside the existing CLIP / open_clip / hf_clip / DeepSparse backends. [Marengo](https://www.twelvelabs.io/) is a video-native multimodal embedding model that embeds text and images into the same vector space as the video segments it produces — useful when your retrieval corpus is video rather than still images.

It follows the same prefix-based selection pattern as the DeepSparse (`nm:`) and open_clip (`open_clip:`) backends: pass a `clip_model` prefixed with `twelvelabs:`, e.g. `--clip_model "twelvelabs:marengo3.0"`.

## Why it helps

clip-retrieval already supports multiple embedding providers behind one knn service. Marengo extends that to a video-native model served via API, so a backend can answer text/image queries against Marengo embeddings without a local GPU.

## Opt-in / non-breaking

- New module `clip_retrieval/marengo.py`; nothing is imported unless a `twelvelabs:` model is requested.
- `twelvelabs` SDK is an **optional** dependency (`pip install clip-retrieval[twelvelabs]`); core install is unchanged.
- Default CLIP path and all existing behavior are untouched — the Marengo branch only activates when `marengo_model` is set.
- Vectors are L2-normalized to match the existing faiss inner-product convention.

## How it was tested

- No-network unit tests in `tests/test_marengo.py` (model selection, name parsing, encode shape/normalization, missing-key error) — pass.
- A gated live smoke test (skipped unless `TWELVELABS_API_KEY` is set) that does a real `marengo3.0` text embedding. Verified locally against the API with `twelvelabs==1.2.8`: returns a `(1, 512)` unit-norm float32 vector.
- `black==23.12.1` (repo-pinned) and `pylint` (10.00/10) clean on the changed files.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
